### PR TITLE
remove a useless argument

### DIFF
--- a/09_Recurrent_Neural_Networks/03_Implementing_LSTM/03_implementing_lstm.py
+++ b/09_Recurrent_Neural_Networks/03_Implementing_LSTM/03_implementing_lstm.py
@@ -178,8 +178,7 @@ class LSTM_Model():
         
         loss_fun = tf.contrib.legacy_seq2seq.sequence_loss_by_example
         loss = loss_fun([self.logit_output],[tf.reshape(self.y_output, [-1])],
-                [tf.ones([self.batch_size * self.training_seq_len])],
-                self.vocab_size)
+                [tf.ones([self.batch_size * self.training_seq_len])])
         self.cost = tf.reduce_sum(loss) / (self.batch_size * self.training_seq_len)
         self.final_state = last_state
         gradients, _ = tf.clip_by_global_norm(tf.gradients(self.cost, tf.trainable_variables()), 4.5)


### PR DESCRIPTION
The argument to `sequence_loss_by_example` after `weights` doesn't make sense. In fact, boolean is expected:
https://www.tensorflow.org/api_docs/python/tf/contrib/legacy_seq2seq/sequence_loss_by_example