### PR TITLE
Fix typo in 05_back_propagation.ipynb

### DIFF
--- a/02_TensorFlow_Way/05_Implementing_Back_Propagation/05_back_propagation.ipynb
+++ b/02_TensorFlow_Way/05_Implementing_Back_Propagation/05_back_propagation.ipynb
@@ -348,7 +348,7 @@
    },
    "outputs": [],
    "source": [
-    "xentropy = tf.nn.sigmoid_cross_entropy_with_logits(logits=my_output_expaneded, labels=y_target_expanded)"
+    "xentropy = tf.nn.sigmoid_cross_entropy_with_logits(logits=my_output_expanded, labels=y_target_expanded)"
    ]
   },
   {


### PR DESCRIPTION
I found the typo when I ran a cell in jupyter notebook so I caught with error "NameError: name 'my_output_expaneded' is not defined".
Anyway, the code in 05_back_propagation.py is okay.