### PR TITLE
the code forget normalized inverse of the distance

### DIFF
--- a/05_Nearest_Neighbor_Methods/02_Working_with_Nearest_Neighbors/02_nearest_neighbor.py
+++ b/05_Nearest_Neighbor_Methods/02_Working_with_Nearest_Neighbors/02_nearest_neighbor.py
@@ -79,6 +79,7 @@ distance = tf.reduce_sum(tf.abs(tf.subtract(x_data_train, tf.expand_dims(x_data_
 # Predict: Get min distance index (Nearest neighbor)
 #prediction = tf.arg_min(distance, 0)
 top_k_xvals, top_k_indices = tf.nn.top_k(tf.negative(distance), k=k)
+top_k_xvals = tf.truediv(1.0, top_k_xvals)
 x_sums = tf.expand_dims(tf.reduce_sum(top_k_xvals, 1),1)
 x_sums_repeated = tf.matmul(x_sums,tf.ones([1, k], tf.float32))
 x_val_weights = tf.expand_dims(tf.div(top_k_xvals,x_sums_repeated), 1)


### PR DESCRIPTION
your: Batch #1 MSE: 14.38
After correction: Batch #1 MSE: 10.625
"We also have to choose how to weight the distances. A straight forward way to weight the distances is by the distance itself. Points that are further away from our prediction should have less impact than nearer points. The most common way to weight is by the normalized inverse of the distance."--according to your "Nearest Neighbor Methods Introduction".